### PR TITLE
Reduce latency by not check for rand module existence

### DIFF
--- a/src/rand_compat.erl
+++ b/src/rand_compat.erl
@@ -50,6 +50,6 @@ uniform(N) ->
         false -> (fun random:uniform/1)(N)
     end.
 
-%% random module is deprecated since releases 19 (ERTS >= 8.0)
+%% random module is deprecated since releases 19 (ERTS >= 8.0). It exists since release 18.
 have_rand() ->
-    (code:which(rand) /= non_existing).
+    list_to_integer(erlang:system_info(otp_release)) > 17.


### PR DESCRIPTION
code:which is a relatively slow function that will add a considerable latency on the exported functions.

Here are some simple benchmark by running the following:
`timer:tc(fun() -> lists:foreach(fun(_) -> rand_compat:uniform() end, lists:seq(1, 10000)) end).`

Erlang 17.5 (master) - `{74447891,ok}`
Erlang 17.5 (reduce_latency) - `{18949,ok}`
Erlang 20 (master) - `{45797,ok}`
Erlang 20 (reduce_latency) - `{10436,ok}`