### PR TITLE
compile out deprecated random module instead of runtime check

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -2,7 +2,7 @@
 {xref_checks, [undefined_function_calls]}.
 {erl_opts, [debug_info,
             warnings_as_errors,
-            {platform_define, "^[0-9]+", namespaced_types}]}.
+            {platform_define, "^((1[8|9])|2)", rand_module}]}.
 {cover_enabled, false}.
 {eunit_opts, [verbose, {report,{eunit_surefire,[{dir,"."}]}}]}.
 {edoc_opts, [{preprocess, true}]}.

--- a/src/rand_compat.erl
+++ b/src/rand_compat.erl
@@ -26,30 +26,34 @@
          uniform/0,
          uniform/1]).
 
+-ifdef(rand_module).
 seed(SValue) ->
-    case have_rand() of
-        true  -> rand:seed(exsplus, SValue);
-        false -> (fun random:seed/1)(SValue)
-    end.
+    rand:seed(exsplus, SValue).
+-else.
+seed(SValue) ->
+    random:seed(SValue).
+-endif.
 
+-ifdef(rand_module).
 seed(A,B,C) ->
-    case have_rand() of
-        true  -> rand:seed(exsplus, {A,B,C});
-        false -> (fun random:seed/3)(A,B,C)
-    end.
+    rand:seed(exsplus, {A,B,C}).
+-else.
+seed(A,B,C) ->
+    random:seed(A,B,C).
+-endif.
 
+-ifdef(rand_module).
 uniform() ->
-    case have_rand() of
-        true  -> rand:uniform();
-        false -> (fun random:uniform/0)()
-    end.
+    rand:uniform().
+-else.
+uniform() ->
+    random:uniform().
+-endif.
 
+-ifdef(rand_module).
 uniform(N) ->
-    case have_rand() of
-        true  -> rand:uniform(N);
-        false -> (fun random:uniform/1)(N)
-    end.
-
-%% random module is deprecated since releases 19 (ERTS >= 8.0). It exists since release 18.
-have_rand() ->
-    list_to_integer(erlang:system_info(otp_release)) > 17.
+    rand:uniform(N).
+-else.
+uniform(N) ->
+    random:uniform(N).
+-endif.


### PR DESCRIPTION
Not sure if there was a reason you wanted the runtime check instead of just compiling out the unused module? If there isn't then this PR should do it.